### PR TITLE
Fix requirements.txt format for tap-s3-csv connector

### DIFF
--- a/singer-connectors/tap-s3-csv/requirements.txt
+++ b/singer-connectors/tap-s3-csv/requirements.txt
@@ -1,1 +1,1 @@
-git://github.com/entera-ai/pipelinewise-tap-s3-csv.git@b25c1c940e8aaf15ae2bfb59087b07f23100086e#egg=pipelinewise-tap-s3-csv
+git+git://github.com/entera-ai/pipelinewise-tap-s3-csv.git@b25c1c940e8aaf15ae2bfb59087b07f23100086e#egg=pipelinewise-tap-s3-csv


### PR DESCRIPTION
Fix requirements.txt format for tap-s3-csv connector; resource must include `git+` at beginning or tap installation will fail