### PR TITLE
upgrade pipelinewise-tap-mysql connector 

### DIFF
--- a/singer-connectors/tap-mysql/requirements.txt
+++ b/singer-connectors/tap-mysql/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-mysql==1.3.8
+pipelinewise-tap-mysql==1.5.0


### PR DESCRIPTION
to version 1.5.0. This should give us PyMySQL v1.0.2 under the hood, which is a requirement for dealing with new character sets in MySQL v8+
